### PR TITLE
FIX: BOTÓN SUBSCRIBE LANDING PAGE

### DIFF
--- a/client/src/pages/landingPage.js
+++ b/client/src/pages/landingPage.js
@@ -303,7 +303,7 @@ const LandingPage = () => {
                 </p>
               </div>
               <div className="mail-form-input-column">
-                <div className="mc-field-group">
+                <div className="mc-field-group input-email-subscribe">
                   <input
                     type="email"
                     name="EMAIL"
@@ -340,7 +340,7 @@ const LandingPage = () => {
                   />
                 </div>
                 <div className="optionalParent">
-                  <div className="clear foot">
+                  <div className="input-subscribe">
                     <input
                       type="submit"
                       value="Suscribirme"

--- a/client/src/static/css/pages/landing.css
+++ b/client/src/static/css/pages/landing.css
@@ -292,6 +292,14 @@
   transform: translateY(-50%);
 }
 
+.input-subscribe{
+  height: 100%;
+}
+
+.input-email-subscribe{
+  margin-right: 30px;
+}
+
 /* RESPONSIVE */
 
 @media screen and (max-width: 1319px) {
@@ -380,7 +388,7 @@
   .mc-field-group{
     width: 100%;
   }
-  
+
   .email-input{
     width: 100%;
     margin-bottom: 20px !important;
@@ -396,6 +404,9 @@
     grid-template-columns: 1fr !important;
   }
 
+  .input-email-subscribe{
+    margin-right: 0px;
+  }
 }
 
 @media screen and (max-width: 440px) {


### PR DESCRIPTION
Arregla el botón de subscripción al final de la landing page. Se le quitan las clases "clear foot" del div ya que agregan reglas css innecesarias. Se agregan nuevas reglas al css para que el boton aparezca centrado y no se superponga con el input del email.