### PR TITLE
FEAT: SELECTOR PROVINCIA Y MUNICIPIO

### DIFF
--- a/client/src/api/propertiesAPI.js
+++ b/client/src/api/propertiesAPI.js
@@ -3,7 +3,8 @@ import {gql} from 'apollo-boost';
 const propertiesAPI = {
     createProperty: gql`
         mutation createProperty($title: String!, $description: String!, $province: String!, $bathroomsNumber: Int!, 
-            $bedroomsNumber: Int!, $dimensions: Int!, $location: String!, $ownerUsername: String!, $price: Float!, $images: [String], $maxCapacity: Int!) {
+            $bedroomsNumber: Int!, $dimensions: Int!, $location: String!, $ownerUsername: String!, $price: Float!, $images: [String], $maxCapacity: Int!,
+            $municipality: String!) {
                 createProperty(
                     title: $title, 
                     description: $description, 
@@ -15,7 +16,8 @@ const propertiesAPI = {
                     province: $province, 
                     price: $price,
                     images: $images,
-                    maxCapacity: $maxCapacity
+                    maxCapacity: $maxCapacity,
+                    municipality: $municipality
                 ) {
                 property {
                     title
@@ -26,7 +28,7 @@ const propertiesAPI = {
     `,
     updateProperty: gql`
         mutation updateProperty($id: Int!, $title: String!, $description: String!, $province: String!, $bathroomsNumber: Int!, 
-            $bedroomsNumber: Int!, $dimensions: Int!, $location: String!, $price: Float!, $images: [String]) {
+            $bedroomsNumber: Int!, $dimensions: Int!, $location: String!, $price: Float!, $images: [String], $municipality: String!) {
                 updateProperty(
                     propertyId: $id,
                     title: $title, 
@@ -36,8 +38,10 @@ const propertiesAPI = {
                     bedroomsNumber: $bedroomsNumber,
                     bathroomsNumber: $bathroomsNumber, 
                     province: $province, 
-                    price: $price
-                    images: $images
+                    price: $price,
+                    images: $images,
+                    municipality: $municipality
+
                 ) {
                 property {
                     title
@@ -60,7 +64,9 @@ const propertiesAPI = {
                     name
                     color
                 }
-                province
+                province{
+                    name
+                }
                 price
                 isOutstanding
                 maxCapacity
@@ -86,7 +92,12 @@ const propertiesAPI = {
                 title
                 price
                 isOutstanding
-                province
+                province{
+                    name
+                }
+                municipality{
+                    name
+                }
                 location
                 dimensions
                 bedroomsNumber
@@ -143,7 +154,12 @@ const propertiesAPI = {
       getPropertyById(id: $id) {
         title
         location
-        province
+        province{
+            name
+        }
+        municipality{
+            name
+        }
         description
         price
         owner {

--- a/client/src/api/provincesAPI.js
+++ b/client/src/api/provincesAPI.js
@@ -1,0 +1,16 @@
+import {gql} from 'apollo-boost';
+
+const provincesApi = {
+    getAllProvincesAndMunicipes: gql`
+        query getAllProvincesAndMunicipes{
+            getProvincesMunicipalities(name: ""){
+                name
+                municipalitySet{
+                    name
+                }
+            }
+        }
+    `,
+}
+
+export default provincesApi;

--- a/client/src/components/forms/flatterForm.js
+++ b/client/src/components/forms/flatterForm.js
@@ -70,7 +70,6 @@ const FlatterForm = forwardRef((props, ref) => {
     return (
         <div className="class-profile-form">
             <form className="class-form" ref={formElement} style={props.numberOfColumns > 1 ? {flexDirection: 'row', flexWrap: 'wrap', justifyContent: 'center'} : {}}>
-                    {props.children}
                     { 
                         Object.keys(formValues).length > 0 && props.inputs.map((input, index) => {
                             return(
@@ -90,6 +89,7 @@ const FlatterForm = forwardRef((props, ref) => {
                             )
                         })
                     }
+                    {props.children}
             </form>
             {
                 props.showSuperAnimatedButton ?

--- a/client/src/components/forms/formProperty.js
+++ b/client/src/components/forms/formProperty.js
@@ -3,15 +3,44 @@ import propertiesAPI from "../../api/propertiesAPI";
 import { propertyInputs } from '../../forms/propertiesForm';
 import FlatterForm from './flatterForm';
 import { useEffect, useRef } from 'react';
+import provincesApi from "../../api/provincesAPI";
+import { useQuery } from "@apollo/client";
+import MunicipalityProvinceSelectors from "../inputs/municipalityProvinceSelectors";
 
 const FormProperty = ({ property }) => {
 
   const client = useApolloClient();
   const createPropertyFormRef = useRef(null);
 
-  function handlePropertySubmit({values}){
+  function updatePropertySubmit({values}){
 
     if(!createPropertyFormRef.current.validate()) return
+
+    client.mutate({
+      mutation: propertiesAPI.updateProperty,
+      variables: {
+        id: parseInt(property.id),
+        title: values.title,
+        description: values.description,
+        province: values.province,
+        bathroomsNumber: parseInt(values.bathroomsNumber),
+        bedroomsNumber: parseInt(values.bedroomsNumber),
+        dimensions: parseInt(values.dimensions),
+        municipality: values.municipality,
+        ownerUsername: localStorage.getItem('user',''),
+        price: parseFloat(values.price),
+        images: values.images,
+        maxCapacity: parseInt(values.maxCapacity),
+        location: values.location
+      }
+    })
+    .then(response => window.location.reload())
+    .catch(error => console.log(error));
+  }
+
+  function createPropertySubmit({values}){
+
+    if(!createPropertyFormRef.current.validate()) return;
 
     client.mutate({
       mutation: propertiesAPI.createProperty,
@@ -22,11 +51,12 @@ const FormProperty = ({ property }) => {
         bathroomsNumber: parseInt(values.bathroomsNumber),
         bedroomsNumber: parseInt(values.bedroomsNumber),
         dimensions: parseInt(values.dimensions),
-        location: values.location,
+        municipality: values.municipality,
         ownerUsername: localStorage.getItem('user',''),
         price: parseFloat(values.price),
         images: values.images,
-        maxCapacity: parseInt(values.maxCapacity)
+        maxCapacity: parseInt(values.maxCapacity),
+        location: values.location
       }
     })
     .then(response => window.location.reload())
@@ -37,10 +67,13 @@ const FormProperty = ({ property }) => {
     if(property){
       propertyInputs.map((input) => {
         input.defaultValue = property[input.name] ? property[input.name].toString() : property[input.name];
-        if(input.name === 'images') input.tag = 'Imágenes de la propiedad (al añadir imágenes, se sustituirán las actuales)';
-    });
+        if(input.name === 'province') input.defaultValue = property.province.name;
+        if(input.name === 'municipality') input.defaultValue = property.municipality.name;
+        if(input.name === 'images') input.tag = 'Imágenes de la propiedad (al añadir imágenes, se sustituirán las actuales)';  
+      });
     }
   }, [property]);
+
 
   return (
     <FlatterForm
@@ -48,10 +81,24 @@ const FormProperty = ({ property }) => {
         showSuperAnimatedButton
         numberOfColumns={3}
         inputs={propertyInputs}
-        onSubmit={handlePropertySubmit}
+        onSubmit={property ? updatePropertySubmit : createPropertySubmit}
         ref={createPropertyFormRef}
         scrollable
-    />
+    >
+      <MunicipalityProvinceSelectors
+        name_province_input={'province'}
+        tag_province_input={'Provincia'}
+        isRequired_province_input={true}
+        defaultValue_province_input={property ? property.province.name : ''}
+        defaultValue_municipality_input={property ? property.municipality.name : ''}
+        validators_province_input={[]}
+        name_municipality_input={'municipality'}
+        tag_municipality_input={'Municipio'}
+        isRequired_municipality_input={true}
+        validators_municipality_input={[]}
+        numberOfColumns={3}
+      />
+    </FlatterForm>
   );
 };
 

--- a/client/src/components/inputs/municipalityProvinceSelectors.js
+++ b/client/src/components/inputs/municipalityProvinceSelectors.js
@@ -1,0 +1,87 @@
+import PropTypes from 'prop-types';
+import { useQuery } from '@apollo/client';
+import provincesApi from '../../api/provincesAPI';
+import { useEffect, useRef, useState } from 'react';
+
+const MunicipalityProvinceSelectors = (props) => {
+ 
+    const provinceInput = useRef(null);
+    const municipalityInput = useRef(null);
+    const [provinceSelected, setProvinceSelected] = useState(props.defaultValue_province_input);
+    const { data, loading } = useQuery(provincesApi.getAllProvincesAndMunicipes);
+    const [ optionMunicipality, setOptionMunicipality ] = useState();
+
+    function handleChange() {
+        setProvinceSelected(provinceInput.current.value);
+    }
+    
+    useEffect(() => { 
+        if(provinceSelected != '' && !loading) {
+            const selectedProvinceData = data.getProvincesMunicipalities.find(province => province.name === provinceSelected);
+            setOptionMunicipality(selectedProvinceData.municipalitySet.map(municipality => municipality.name));
+        }
+    }, [data, provinceSelected]);
+    
+    if(loading) return <p>Loading...</p>
+    const options = data.getProvincesMunicipalities.map(province => province.name);
+
+    return (
+        <>
+            <div className={`class-form-group`} id={props.name_province_input+`_form`} style={props.numberOfColumns>1 ? {paddingTop: `2%`, width: `${100/props.numberOfColumns-3}%`} : {marginTop: `7.5%`}}>	
+                <select className="class-form-input" id={props.name_province_input} name={props.name_province_input} required={props.isRequired_province_input} defaultValue={props.defaultValue_province_input} onChange={handleChange} ref={provinceInput}>
+                    {
+                        options && options.map((option, index) => {
+                            return(
+                                <option key={index}>{option}</option>
+                            )
+                        })
+                    }
+                </select>
+                <label htmlFor={props.name} className="class-form-label" style={props.numberOfColumns>1 ? {paddingLeft: `1%`} : {}}>{props.tag_province_input}:</label>
+            </div>
+            <div className={`class-form-group`} id={props.name_municipality_input+`_form`} style={props.numberOfColumns>1 ? {paddingTop: `2%`, width: `${100/props.numberOfColumns-3}%`} : {marginTop: `7.5%`}}>	
+                <select className="class-form-input" id={props.name_municipality_input} name={props.name_municipality_input} required={props.isRequired_municipality_input} defaultValue={props.defaultValue_municipality_input} ref={municipalityInput}>
+                    {
+                        optionMunicipality && optionMunicipality.map((option, index) => {
+                            return(
+                                <option key={index}>{option}</option>
+                            )
+                        })
+                    }
+                </select>
+                <label htmlFor={props.name_municipality_input} className="class-form-label" style={props.numberOfColumns>1 ? {paddingLeft: `1%`} : {}}>{props.tag_municipality_input}:</label>
+            </div>
+        </>
+    )
+}
+
+MunicipalityProvinceSelectors.propTypes = {
+    name_province_input: PropTypes.string.isRequired,
+    tag_province_input: PropTypes.string.isRequired,
+    defaultValue_province_input: PropTypes.string.isRequired,
+    isRequired_province_input: PropTypes.bool.isRequired,
+    validators_province_input: PropTypes.array.isRequired,
+    name_municipality_input: PropTypes.string.isRequired,
+    tag_municipality_input: PropTypes.string.isRequired,
+    defaultValue_municipality_input: PropTypes.string.isRequired,
+    isRequired_municipality_input: PropTypes.bool.isRequired,
+    validators_municipality_input: PropTypes.array.isRequired,
+    numberOfColumns: PropTypes.number.isRequired
+}
+
+MunicipalityProvinceSelectors.defaultProps = {
+    name_province_input: "default",
+    tag_province_input: "default",
+    defaultValue_province_input: "",
+    isRequired_province_input: false,
+    validators_province_input: [],
+    name_municipality_input: "default",
+    tag_municipality_input: "default",
+    defaultValue_municipality_input: "",
+    isRequired_municipality_input: false,
+    validators_municipality_input: [],
+    numberOfColumns: 1
+}
+
+
+export default MunicipalityProvinceSelectors

--- a/client/src/forms/propertiesForm.js
+++ b/client/src/forms/propertiesForm.js
@@ -24,17 +24,7 @@ export const propertyInputs = [
       ]
     },
     {
-      tag: 'Provincia',
-      name: 'province',
-      type: 'text',
-      defaultValue: "",
-      isRequired: true,
-      validators: [
-        propertyValidators.notEmptyValidator
-      ]
-    },
-    {
-      tag: 'Municipio',
+      tag: 'Localización',
       name: 'location',
       type: 'text',
       defaultValue: "",

--- a/client/src/pages/listProperties.js
+++ b/client/src/pages/listProperties.js
@@ -118,7 +118,7 @@ const ListProperties = () => {
                     </div>
     
                     <div className="meta-left">
-                      <div className="meta-location"><img className="small-picture-back" src={require('../static/files/icons/ubicacion.png')} alt='Ubicacion'/> { property.province }</div>
+                      <div className="meta-location"><img className="small-picture-back" src={require('../static/files/icons/ubicacion.png')} alt='Ubicacion'/> { property.province.name }</div>
     
                       <div className="meta-flatmates"><img className="small-picture-back" src={require('../static/files/icons/partners.png')} alt='Compañeros'/> {property.flatmates.length}/{property.maxFlatmates}</div>
                     </div>

--- a/client/src/pages/ownerProperties.js
+++ b/client/src/pages/ownerProperties.js
@@ -99,7 +99,7 @@ const OwnerProperties = ({}) => {
               <div className="attrcontainer"> 
                 <div className="attrindv">
                   <img className="small-picture-back" src={require('../static/files/icons/ubicacion.png')} alt='Ubicacion'/>
-                  <p className = "location">{prop.province}</p>  
+                  <p className = "location">{prop.location}</p>  
                 </div>
                 <div className="attrindv">
                   <p className = "team">{prop.price} €/mes</p>
@@ -156,7 +156,7 @@ const OwnerProperties = ({}) => {
       </section>
 
       <FlatterModal maxWidth={700} ref={addPropertyModalRef}>
-        <FormProperty property={{}} />
+        <FormProperty/>
       </FlatterModal>
 
       <FlatterModal maxWidth={700} ref={editPropertyModalRef}>

--- a/client/src/pages/propertyDetails.js
+++ b/client/src/pages/propertyDetails.js
@@ -40,7 +40,7 @@ const PropertyDetails = () => {
           <div className="property-housing__info">
             <div className="property-title">
               <h1>{data.getPropertyById.title}</h1>
-              <span>LOCALIZACIÓN: {data.getPropertyById.province}, {data.getPropertyById.location}</span>
+              <span>LOCALIZACIÓN: {data.getPropertyById.province.name}, {data.getPropertyById.municipality.name}, {data.getPropertyById.location}</span>
             </div>
             <div className="property-price">
               <span>{data.getPropertyById.price}</span> <span>€/mes</span>


### PR DESCRIPTION
- Creado componente de dos selectores que cargan de la base de datos las provincias y municipios de España. 
- El componente se emplea en la creación y edición de propiedades.
- Las opciones del selector de municipios cambia según la provincia seleccionada. 
- También se han actualizado las vistas donde se visualizaban los datos de la propiedad para que se muestren los nombres de provincia y municipio, ya que tras el cambio en backend existían errores. 
- A su vez se han actualizado algunas querys de propertiesAPI para que devuelven el nombre de provincia y municipio.
- Se corrige un bug que hacía que al actualizar una propiedad se crease una nueva.