### PR TITLE
FIX: SOLUCIONADO ERROR DE MUNICIPIO AL EDITAR PROPIEDAD.

### DIFF
--- a/client/src/components/forms/formProperty.js
+++ b/client/src/components/forms/formProperty.js
@@ -69,20 +69,20 @@ const FormProperty = ({ property }) => {
 
         if(input.name === 'municipality') {
           input.defaultValue = property.municipality.name;
-          client.query({
-            query: provincesAPI.getMunicipalitiesByProvince,
-            variables: {
-              province: property.province.name
-            }
-          })
-          .then(response => {
+           client.query({
+             query: provincesAPI.getMunicipalitiesByProvince,
+             variables: {
+               province: property.province.name
+             }
+           })
+           .then(response => {
 
             let municipalityOptions = response.data.getMunicipalitiesByProvince.map(municipality => municipality.name);
-
-            setOptionMunicipality(municipalityOptions);
+            municipalityOptions = municipalityOptions.filter(municipality => municipality !== property.municipality.name);
+            setOptionMunicipality([property.municipality.name].concat(municipalityOptions));
             input.values = municipalityOptions;
-          })
-          .catch(error => console.log(error));
+           })
+           .catch(error => console.log(error));
         };
 
         if(input.name === 'images') input.tag = 'Imágenes de la propiedad (al añadir imágenes, se sustituirán las actuales)';  


### PR DESCRIPTION
Antes, cuando editabamos una propiedad por primera vez, esta tenía por defecto el primer municipio de la lista de municipios esa ciudad. Ahora ya está solucionado y tanto la primera vez como todas las demás veces que accedamos a editar nuestra propiedad, el municipio por defecto será el asignado a la propiedad en cuestión.