### PR TITLE
FEAT: FILTRO DE USUARIOS Y PROPIEDADES

### DIFF
--- a/backend/authentication/queries.py
+++ b/backend/authentication/queries.py
@@ -22,7 +22,7 @@ class AuthenticationQuery(object):
     q = Q()
 
     if tag:    
-      q &= Q(tags__icontains = tag)
+      q &= Q(tags__name__icontains = tag)
       
     if owner is not None and owner:
       q &= Q(roles__in = [Role.objects.get(role="OWNER").pk])

--- a/backend/mainApp/queries.py
+++ b/backend/mainApp/queries.py
@@ -17,7 +17,8 @@ class MainAppQuery(object):
     get_properties = graphene.List(PropertyType)
     get_filtered_properties_by_price_and_city = graphene.List(PropertyType, min_price=graphene.Float(),
                                                               max_price=graphene.Float(), municipality=graphene.String(),
-                                                              location=graphene.String(), province=graphene.String())
+                                                              location=graphene.String(), province=graphene.String(),
+                                                              tag=graphene.String())
     get_filtered_properties_by_province_municipality_location = graphene.List(PropertyType, province=graphene.String(),
                                                                               municipality=graphene.String(),
                                                                               location=graphene.String())
@@ -47,7 +48,7 @@ class MainAppQuery(object):
         return property.tags.all()
 
     def resolve_get_filtered_properties_by_price_and_city(self, info, max_price=None, min_price=None, municipality=None,
-                                                          location=None, province=None):
+                                                          location=None, province=None, tag=None):
         q = Q()
 
         if min_price and max_price and max_price < min_price:
@@ -75,6 +76,9 @@ class MainAppQuery(object):
 
         if location:
             q &= Q(location=location)
+
+        if tag:
+            q &= Q(tags__name__icontains = tag)
 
         properties = Property.objects.filter(q)
 

--- a/backend/social/fixtures/tags.json
+++ b/backend/social/fixtures/tags.json
@@ -691,6 +691,42 @@
       "entity": "U",
       "color": "#FF5722"
     }
+  },
+  {
+    "model": "authentication.tag",
+    "pk": 78,
+    "fields": {
+      "name": "Familiar",
+      "entity": "P",
+      "color": "#FF9800"
+    }
+  },
+  {
+    "model": "authentication.tag",
+    "pk": 79,
+    "fields": {
+      "name": "Estudiantes",
+      "entity": "P",
+      "color": "#9C27B0"
+    }
+  },
+  {
+    "model": "authentication.tag",
+    "pk": 80,
+    "fields": {
+      "name": "Rural",
+      "entity": "P",
+      "color": "#FF5722"
+    }
+  },
+  {
+    "model": "authentication.tag",
+    "pk": 81,
+    "fields": {
+      "name": "Ciudad",
+      "entity": "P",
+      "color": "#FFC107"
+    }
   }
 ]
 

--- a/client/src/api/propertiesAPI.js
+++ b/client/src/api/propertiesAPI.js
@@ -72,8 +72,8 @@ const propertiesAPI = {
     }
     `,
     filterProperties: gql`
-        query filterProperties($minPrice: Float, $maxPrice: Float, $municipality: String) {
-          getFilteredPropertiesByPriceAndCity(minPrice: $minPrice, maxPrice: $maxPrice, municipality: $municipality) {
+        query filterProperties($minPrice: Float, $maxPrice: Float, $municipality: String, $province: String, $tag: String) {
+          getFilteredPropertiesByPriceAndCity(minPrice: $minPrice, maxPrice: $maxPrice, municipality: $municipality, province: $province, tag: $tag) {
                 id
                 title
                 description

--- a/client/src/api/usersAPI.js
+++ b/client/src/api/usersAPI.js
@@ -145,6 +145,10 @@ const usersAPI = {
                 profilePicture
                 profession
                 averageRating
+                tags{
+                    name
+                    color
+                }
             }
         }
     `,

--- a/client/src/components/forms/formProperty.js
+++ b/client/src/components/forms/formProperty.js
@@ -7,6 +7,8 @@ import { propertyInputs } from '../../forms/propertiesForm';
 import { useEffect, useRef } from 'react';
 import { useQuery } from "@apollo/client";
 import { useState } from "react";
+import TagSelector from '../inputs/tagSelector';
+import tagsAPI from '../../api/tagsAPI';
 
 const FormProperty = ({ property }) => {
 
@@ -18,7 +20,16 @@ const FormProperty = ({ property }) => {
   const [configured, setConfigured] = useState(false);
   const [inputsChanged, setInputsChanged] = useState(false);
 
+  const {data: propertyTagsData, loading: propertyTagsLoading} = useQuery(tagsAPI.getTagsByType, {
+    variables: {
+        type: "property"
+    }
+  });
+  const tagsInput = useRef(null);
+  
   function createPropertySubmit({values}){
+
+    let tagsValues = tagsInput.current.props.value.map(tag => tag.value);
 
     if(!createPropertyFormRef.current.validate()) return;
 
@@ -36,7 +47,8 @@ const FormProperty = ({ property }) => {
         price: parseFloat(values.price),
         images: values.images,
         maxCapacity: parseInt(values.maxCapacity),
-        location: values.location
+        location: values.location,
+        tags: tagsValues
       }
     } : {
       mutation: propertiesAPI.updateProperty,
@@ -53,7 +65,8 @@ const FormProperty = ({ property }) => {
         ownerUsername: localStorage.getItem('user',''),
         price: parseFloat(values.price),
         images: values.images,
-        maxCapacity: parseInt(values.maxCapacity)
+        maxCapacity: parseInt(values.maxCapacity),
+        tags: tagsValues
       }
     })
     .then(response => window.location.reload())
@@ -161,7 +174,30 @@ const FormProperty = ({ property }) => {
         onSubmit={createPropertySubmit}
         ref={createPropertyFormRef}
         scrollable
-    />
+    >
+      <div className='tag-input'>
+          {
+              !propertyTagsLoading && 
+                  <TagSelector 
+                      options={propertyTagsData.getTagsByType.map(tag => {
+                                  return {
+                                          value: tag.id,
+                                          name: tag.name, 
+                                          color: tag.color
+                                      }
+                              })}
+                      defaultValues={property?property.tags.map(tag => {
+                                  return {
+                                          value: tag.id,
+                                          name: tag.name,
+                                          color: tag.color
+                                      }
+                              }):[]}
+                      max={8} 
+                      ref={tagsInput}/>
+          }
+      </div>
+    </FlatterForm>
   );
 };
 

--- a/client/src/components/users/userCards.js
+++ b/client/src/components/users/userCards.js
@@ -1,6 +1,7 @@
 import '../../static/css/components/userCard.css';
 import * as settings from "../../settings";
 import { useNavigate } from "react-router-dom";
+import Tag from '../tag';
 
 const UserCard = ({ user }) => {
 
@@ -18,6 +19,19 @@ const UserCard = ({ user }) => {
                 <div className='average-rating-bubble'>
                     <span>{user.averageRating !== 0 ? user.averageRating.toFixed(2) : '-'}</span>
                 </div>
+                <div className='tags-container'>
+                        {
+                            user.tags.length !== 0 ? (
+                                user.tags.map((tag, i) => { 
+                                    return(
+                                        <Tag key={'tag-'+i} name={tag.name} color={tag.color} />
+                                    )
+                                })
+                            ) : (
+                                <></>
+                            )
+                        }
+                    </div>
             </div>
         </div>
     );

--- a/client/src/components/users/userCards.js
+++ b/client/src/components/users/userCards.js
@@ -8,8 +8,8 @@ const UserCard = ({ user }) => {
     const navigate = useNavigate();
 
     return (
-        <div className="user-card" onClick={() => navigate(`/profile/${user.username}`)}>
-            <div className="user-card__avatar">
+        <div className="user-card">
+            <div className="user-card__avatar" onClick={() => navigate(`/profile/${user.username}`)}>
                 <img src={settings.API_SERVER_MEDIA + user.profilePicture} alt="Avatar" />
             </div>
             <div className="user-card__info">
@@ -20,18 +20,20 @@ const UserCard = ({ user }) => {
                     <span>{user.averageRating !== 0 ? user.averageRating.toFixed(2) : '-'}</span>
                 </div>
                 <div className='tags-container'>
-                        {
-                            user.tags.length !== 0 ? (
-                                user.tags.map((tag, i) => { 
-                                    return(
-                                        <Tag key={'tag-'+i} name={tag.name} color={tag.color} />
-                                    )
-                                })
-                            ) : (
-                                <></>
-                            )
-                        }
-                    </div>
+                    {
+                        user.tags.length !== 0 ? (
+                            user.tags.map((tag, i) => { 
+                                return(
+                                    <div className="tagDiv" onClick={() => navigate(`/users?tag=${tag.name}`)}>
+                                        <Tag key={'tag-'+i} name={tag.name} color={tag.color}/>
+                                    </div>
+                                )
+                            })
+                        ) : (
+                            <></>
+                        )
+                    }
+                </div>
             </div>
         </div>
     );

--- a/client/src/forms/filterPropertiesForm.js
+++ b/client/src/forms/filterPropertiesForm.js
@@ -2,10 +2,32 @@ import { registerValidators } from "../libs/validators/registerValidators"
 
 export const filterInputs = [
     {
+        tag: "Provincia",
+        name: "province",
+        type: "select",
+        values: ["-"],
+        defaultValue: "-",
+        isRequired: false,
+        validators: [
+            registerValidators.noNumbersValidator,
+        ]
+    },
+    {
         tag: "Municipio",
         name: "municipality",
-        type: "text",
-        defaultValue: "",
+        type: "select",
+        values: ["-"],
+        defaultValue: "-",
+        isRequired: false,
+        validators: [
+            registerValidators.noNumbersValidator,
+        ]
+    },
+    {
+        tag: "Etiqueta",
+        name: "tag",
+        type: "select",
+        values: [],
         isRequired: false,
         validators: [
             registerValidators.noNumbersValidator,

--- a/client/src/forms/filterUsersForm.js
+++ b/client/src/forms/filterUsersForm.js
@@ -4,8 +4,8 @@ export const filterInputs = [
     {
         tag: "Etiqueta",
         name: "tag",
-        type: "text",
-        defaultValue: "",
+        type: "select",
+        values: [],
         isRequired: false,
         validators: [
             registerValidators.noNumbersValidator,

--- a/client/src/pages/listProperties.js
+++ b/client/src/pages/listProperties.js
@@ -11,9 +11,11 @@ import useURLQuery from "../hooks/useURLQuery";
 import { useState, useEffect, useRef } from "react";
 import { filterInputs } from "../forms/filterPropertiesForm";
 import {useNavigate} from 'react-router-dom';
-import {useApolloClient} from '@apollo/client';
+import {useApolloClient, useQuery} from '@apollo/client';
 import customAlert from "../libs/functions/customAlert";
 import FlatterModal from "../components/flatterModal";
+import provincesAPI from "../api/provincesAPI";
+import tagsAPI from "../api/tagsAPI";
 
 const ListProperties = () => {
 
@@ -21,11 +23,23 @@ const ListProperties = () => {
   const navigator = useNavigate();
   const client = useApolloClient();
   const filterFormRef = useRef(null);
+  const {data: provincesData, loading: provincesLoading} = useQuery(provincesAPI.getAllProvinces);
+  const [ optionMunicipality, setOptionMunicipality ] = useState([]);
+  const [configured, setConfigured] = useState(false);
+  const [inputsChanged, setInputsChanged] = useState(false);
+  const {data: propertyTagsData, loading: propertyTagsLoading} = useQuery(tagsAPI.getTagsByType, {
+    variables: {
+        type: "property"
+    }
+  }); 
+
 
   let [filterValues, setFilterValues] = useState({
     min: parseInt(query.get("min")),
     max: parseInt(query.get("max")),
     municipality: query.get("municipality") ?? '',
+    province: query.get("province") ?? '',
+    tag: query.get("tag") ?? '',
   });
 
   let [sharedProperty, setSharedProperty] = useState({});
@@ -41,10 +55,23 @@ const ListProperties = () => {
     setFilterValues({
       min: values.min_price,
       max: values.max_price,
-      municipality: values.municipality
+      municipality: values.municipality==='-' ? '' : values.municipality,
+      province: values.province === '-' ? '' : values.province,
+      tag: values.tag === '-'? null : values.tag,
     })
 
   }
+
+  useEffect(() => { 
+    if (!propertyTagsLoading) { 
+        filterInputs.map((input) => { 
+            if(input.name === 'tag') { 
+              const tagNames = propertyTagsData.getTagsByType.map(tag => tag.name);
+              input.values = ['-'].concat(tagNames);            
+            } 
+        }) 
+      }
+    }, [propertyTagsLoading, propertyTagsData]);
 
   useEffect(() => {
 
@@ -53,7 +80,9 @@ const ListProperties = () => {
       variables: {
         minPrice: filterValues.min,
         maxPrice: filterValues.max,
-        municipality: filterValues.municipality
+        municipality: filterValues.municipality,
+        province: filterValues.province,
+        tag: filterValues.tag,
       }
     })
     .then((response) => setProperties(response.data.getFilteredPropertiesByPriceAndCity))
@@ -75,6 +104,56 @@ const ListProperties = () => {
       .then(customAlert("¡Ya puedes compartir la propiedad!"))
       .catch(error => console.log(error));;
   }
+
+  useEffect(() => { 
+    if(!provincesLoading){
+      filterInputs.map((input) => {
+        if(input.name === 'province') input.values = ['-'].concat(provincesData.getProvinces.map(province => province.name));
+      });
+    }
+
+  }, [provincesLoading]);
+
+    useEffect(() => {
+      if(optionMunicipality.length > 0){
+        filterInputs.map((input) => {
+          if(input.name === 'municipality') {
+            input.values = ["-"].concat(optionMunicipality);
+          }
+        });
+        setInputsChanged(!inputsChanged);
+      }
+    }, [optionMunicipality]);
+  
+
+    useEffect(() => {
+      if(!configured){
+        setTimeout(() => {
+          let provinceInput = document.querySelector('select#province');
+    
+          provinceInput.addEventListener('change', () => {
+    
+            client.query({
+              query: provincesAPI.getMunicipalitiesByProvince,
+              variables: {
+                province: provinceInput.value
+              }
+            })
+            .then(response => {
+              if(provinceInput.value !== "-"){
+                setOptionMunicipality(response.data.getMunicipalitiesByProvince.map(municipality => municipality.name));
+              }else{
+                setOptionMunicipality(["-"]);
+              }
+            })
+            .catch(error => console.log(error));
+    
+          });
+  
+          setConfigured(true);
+        }, 1000);
+      }
+    }, [inputsChanged]);
 
 
 

--- a/client/src/pages/searchUsers.js
+++ b/client/src/pages/searchUsers.js
@@ -4,20 +4,28 @@ import FlatterPage from "../sections/flatterPage";
 import useURLQuery from "../hooks/useURLQuery";
 import { useState, useEffect, useRef } from "react";
 import { filterInputs } from "../forms/filterUsersForm";
-import {useNavigate} from 'react-router-dom';
-import {useApolloClient} from '@apollo/client';
+import {useLocation, useNavigate} from 'react-router-dom';
+import {useApolloClient, useQuery} from '@apollo/client';
 import usersAPI from "../api/usersAPI";
 import UserCard from "../components/users/userCards";
 import FlatterForm from "../components/forms/flatterForm";
 import SolidButton from "../sections/solidButton";
 import customAlert from "../libs/functions/customAlert";
+import tagsAPI from "../api/tagsAPI";
 
 const SearchUsers = () => {
+
+  const location = useLocation();
 
   const query = useURLQuery();
   const navigator = useNavigate();
   const client = useApolloClient();
   const filterFormRef = useRef(null);
+  const {data: userTagsData, loading: userTagsLoading} = useQuery(tagsAPI.getTagsByType, {
+    variables: {
+        type: "user"
+    }
+  }); 
 
   let [filterValues, setFilterValues] = useState({
     min: parseInt(query.get("min")),
@@ -26,6 +34,20 @@ const SearchUsers = () => {
     owner: query.get("owner") ? (query.get("owner") === 'true' ? true : false) : null,
   });
 
+  useEffect(() => {
+    const searchParams = new URLSearchParams(location.search);
+    const min = parseInt(searchParams.get("min")) || 0;
+    const max = parseInt(searchParams.get("max")) || 5;
+    const tag = searchParams.get("tag") || "";
+    const owner = searchParams.get("owner")
+      ? searchParams.get("owner") === "true"
+        ? true
+        : false
+      : null;
+
+    setFilterValues({ min, max, tag, owner });
+  }, [location]);
+  
   let [users, setUsers] = useState([]);
 
   function handleFilterForm({values}) {
@@ -35,7 +57,7 @@ const SearchUsers = () => {
     setFilterValues({
         min: values.min_rating,
         max: values.max_rating,
-        tag: values.province,
+        tag: values.tag === '-'? null : values.tag,
         owner: values.role === 'Propietario' ? true : values.role === 'Inquilino' ? false : null
     })
 
@@ -69,9 +91,18 @@ const SearchUsers = () => {
     //eslint-disable-next-line
   }, [filterValues]);
 
+  useEffect(() => { 
+    if (!userTagsLoading) { 
+        filterInputs.map((input) => { 
+            if(input.name === 'tag') { 
+              const tagNames = userTagsData.getTagsByType.map(tag => tag.name);
+              input.values = ['-'].concat(tagNames);            
+            } 
+        }) 
+      }
+    }, [userTagsLoading, userTagsData]);
 
-
-  return (
+    return (
     <FlatterPage withBackground userLogged>
       <div>
         <h1 className="properties-title">Buscar a otros usuarios</h1>

--- a/client/src/static/css/components/userCard.css
+++ b/client/src/static/css/components/userCard.css
@@ -6,13 +6,13 @@
   border: 1px solid rgb(0, 57, 85);
   margin: 0 5%;
   padding: 20px;
-  cursor: pointer;
 }
 
 .user-card__avatar{
   width: 100%;
   display: flex;
   justify-content: center;
+  cursor: pointer;
 }
 
 .user-card__avatar img{
@@ -65,4 +65,8 @@
 
 .user-card:hover .user-card__avatar img{
   border: 3px solid green;
+}
+
+.tagDiv{
+  cursor: pointer;
 }


### PR DESCRIPTION
- Se modifica en backend la query de filtrar propiedades para que acepte etiquetas.
- Se corrige en backend la query de filtrar usuarios porque no se filtraba por las etiquetas correctamente.
- Se añaden ejemplos de etiquetas en fixtures para que existan etiquetas para propiedades.
- En frontend se habilita la posibilidad de filtrar usuarios por etiquetas.
- Se añaden las etiquetas a la vista de userCard.
- Si pulsas en la etiqueta de la card de un usuario, se realiza un filtro por dicha etiqueta.
- Se habilita el filtro por municipio y provincias de propiedades haciendo también funcionales los selects.
- En el formulario de edición y creación de propiedades se añade el campo de etiquetas, aunque no es funcional ya que falta corregir la mutación en backend añadiendo dicho campo