### PR TITLE
FEAT: TAGS CREACIÓN Y EDICIÓN DE PROPIEDAD

### DIFF
--- a/client/src/api/propertiesAPI.js
+++ b/client/src/api/propertiesAPI.js
@@ -15,6 +15,7 @@ const propertiesAPI = {
       $price: Float!
       $images: [String]
       $maxCapacity: Int!
+      $tags: [String]!
     ) {
       createProperty(
         title: $title
@@ -29,6 +30,7 @@ const propertiesAPI = {
         price: $price
         images: $images
         maxCapacity: $maxCapacity
+        tags: $tags
       ) {
         property {
           title
@@ -50,6 +52,7 @@ const propertiesAPI = {
       $municipality: String!
       $price: Float!
       $images: [String]
+      $tags: [String]!
     ) {
       updateProperty(
         propertyId: $id
@@ -63,6 +66,7 @@ const propertiesAPI = {
         municipality: $municipality
         price: $price
         images: $images
+        tags: $tags
       ) {
         property {
           title

--- a/client/src/components/forms/formProperty.js
+++ b/client/src/components/forms/formProperty.js
@@ -22,7 +22,7 @@ const FormProperty = ({ property }) => {
 
   const {data: propertyTagsData, loading: propertyTagsLoading} = useQuery(tagsAPI.getTagsByType, {
     variables: {
-        type: "property"
+        type: "P"
     }
   });
   const tagsInput = useRef(null);

--- a/client/src/components/profile/publicProfileCard.js
+++ b/client/src/components/profile/publicProfileCard.js
@@ -26,7 +26,7 @@ const PublicProfileCard = (props) => {
 
     const {data: userTagsData, loading: userTagsLoading} = useQuery(tagsAPI.getTagsByType, {
         variables: {
-            type: "user"
+            type: "U"
         }
     });
 

--- a/client/src/pages/listProperties.js
+++ b/client/src/pages/listProperties.js
@@ -29,7 +29,7 @@ const ListProperties = () => {
   const [inputsChanged, setInputsChanged] = useState(false);
   const {data: propertyTagsData, loading: propertyTagsLoading} = useQuery(tagsAPI.getTagsByType, {
     variables: {
-        type: "property"
+        type: "P"
     }
   }); 
 

--- a/client/src/pages/searchUsers.js
+++ b/client/src/pages/searchUsers.js
@@ -23,7 +23,7 @@ const SearchUsers = () => {
   const filterFormRef = useRef(null);
   const {data: userTagsData, loading: userTagsLoading} = useQuery(tagsAPI.getTagsByType, {
     variables: {
-        type: "user"
+        type: "U"
     }
   }); 
 


### PR DESCRIPTION
Ahora el input de tags es funcional cuando se crea o actualiza un inmueble. 
También se arregla un error de publicProfileCard, ya que al haber cambiado la query en backend, se rompía dicha vista.